### PR TITLE
CIのブランチ名を修正

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Check
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   publish:

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Github Jupyter diff viewer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "manifest_version": 2,
   "description": "Diff viewer for jupyter file(*.ipynb) in Github",
   "permissions": [


### PR DESCRIPTION
# 概要

- github actionsのブランチ名をmain -> masterに修正

# 動作確認
